### PR TITLE
修改security中auth顺序，session cookie path 设定到 "/"

### DIFF
--- a/session.go
+++ b/session.go
@@ -166,6 +166,7 @@ func (handler *sessionHandler) ServeHTTP(writer http.ResponseWriter, request *ht
 			Name:   sessionIDCookieKey,
 			Value:  session.ID,
 			MaxAge: 60 * 60 * 24, // for one day
+			Path: 	"/",
 		}
 
 		http.SetCookie(writer, cookie)


### PR DESCRIPTION
修改auth顺序，避免访问静态资源时也调用provider Authenticate
未设定cookie path时会导致访问不到session